### PR TITLE
add: focus and input ref

### DIFF
--- a/src/lib/Components/Add.svelte
+++ b/src/lib/Components/Add.svelte
@@ -1,31 +1,33 @@
 <script lang="ts">
   import Todo from "../Todo.svelte";
-
   const _todo = Todo.instance();
 
-  let title = $state<string>("");
+  let titleInputEl: HTMLInputElement;
+
   let error = $state<string>("");
 
   const handleSubmit = (e: SubmitEvent) => {
     e.preventDefault();
     e.stopPropagation();
 
-    error = "";
+    const title = titleInputEl.value.trim();
 
-    if (title.trim() === "") {
+    if (title === "") {
+      titleInputEl.value = title;
+      titleInputEl.focus();
       error = "Title cannot be empty";
       return;
     }
 
-    const todo: ITodo = {
+    _todo.add({
       id: crypto.randomUUID(),
       title: title.trim(),
       done: false,
-    };
+    });
 
-    _todo.add(todo);
-
-    title = "";
+    error = "";
+    titleInputEl.value = "";
+    titleInputEl.focus();
 
     return;
   };
@@ -34,7 +36,11 @@
 <form onsubmit={handleSubmit}>
   <!-- svelte-ignore a11y_no_redundant_roles -->
   <fieldset role="group">
-    <input type="text" placeholder="Enter todo title..." bind:value={title} />
+    <input
+      type="text"
+      placeholder="Enter todo title..."
+      bind:this={titleInputEl}
+    />
     <input type="submit" value="Add" />
   </fieldset>
   {#if error !== ""}


### PR DESCRIPTION
This pull request refactors the `Add.svelte` component to improve input handling and user experience when adding new todos. The key changes include replacing the two-way binding with a direct reference to the input element, refining error handling, and ensuring the input field is reset and focused after submission.

### Input handling improvements:
* Replaced the `bind:value` two-way binding on the input field with a `bind:this` reference to the input element (`titleInputEl`), allowing direct manipulation of its value.

### Error handling and UX enhancements:
* Modified the `handleSubmit` function to reset the input field and focus on it when the title is empty or after a successful submission. This ensures a smoother user experience.